### PR TITLE
Make last updated footer live

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,29 @@
 import GitHubIcon from "@mui/icons-material/GitHub";
-import { Typography, IconButton, styled } from "@mui/material";
+import { IconButton, Typography, styled } from "@mui/material";
+import { useEffect, useState } from "react";
+
+const BASE_URL = process.env.REACT_APP_API_URL;
+const LAST_UPDATED_URL = `${BASE_URL}api/v1/last-updated`;
+const DATE_OPTIONS = { year: "numeric", month: "long", day: "numeric" };
+
+function unixTimeToDate(unixTime) {
+  return new Date(1000 * unixTime); // Unix epoch time is seconds, javascript date uses ms
+}
+
+function dateToDisplayString(date) {
+  return date.toLocaleString("en-US", DATE_OPTIONS);
+}
 
 const UnstyledFooter = ({ className }) => {
+  const [lastUpdated, setLastUpdated] = useState("Unknown");
+
+  useEffect(() => {
+    fetch(LAST_UPDATED_URL)
+      .then((res) => res.json())
+      .then((json) => setLastUpdated(unixTimeToDate(json.lastUpdated)))
+      .catch((err) => console.log(`Error fetching last updated: ${err}`));
+  }, []);
+
   return (
     <footer className={className}>
       <IconButton
@@ -13,7 +35,7 @@ const UnstyledFooter = ({ className }) => {
         <GitHubIcon fontSize="large" />
       </IconButton>
       <Typography variant="caption" color="secondary">
-        <div>Last updated Nov 3</div>
+        <div>{`Last updated ${dateToDisplayString(lastUpdated)}`}</div>
       </Typography>
     </footer>
   );


### PR DESCRIPTION
New footer pulls data from https://schedubuddy1.herokuapp.com/api/v1/last-updated