### PR TITLE
Add more possible block colors

### DIFF
--- a/src/components/Schedule.jsx
+++ b/src/components/Schedule.jsx
@@ -21,6 +21,16 @@ const colorOrder = [
   "#FFCC99",
   "#9999FF",
   "#CCFFFF",
+  "#FF6666",
+  "#FFFF66",
+  "#66FF66",
+  "#6699FF",
+  "#9966FF",
+  "#FF6699",
+  "#66FFCC",
+  "#FFCC66",
+  "#6666FF",
+  "#99FFFF",
 ];
 const hourPadding = 0;
 


### PR DESCRIPTION
Adding more colors (A superset of the original beartracks colors). I can come up with a formula if wanted but seems unnecessary.

Only 10 possible colors, increasing to 20. Should avoid the following color overlap:
![image](https://github.com/aarctan/schedubuddy-web/assets/60676925/bf1032d2-2431-4f79-9465-1477a54722c7)


New:
![image](https://github.com/aarctan/schedubuddy-web/assets/60676925/10bffbf8-1a0b-476b-87d2-db42a13b3b8b)
