### PR TITLE
feat: display term name on generated schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This is the repo for the app's front-end; **for the back-end, please refer to this [repo](https://github.com/Exanut/schedubuddy-server).**
 
 ### Usage
+
 Schedubuddy was designed to be lightweight and intuitive, while also powerful.
 To try it out, simply select an academic term, enter courses from the autocomplete, tune your preferences, and hit "Get Schedules".
 After computing, the top schedules will be displayed in the order given by the ranking algorithm.
@@ -11,4 +12,4 @@ Other features include viewing all the classes that occur in a given lecture roo
 
 ### Contributing
 
-As an open source porject, we welcome feedback from users or developers in the form of comments or proposals for new features or changes. 
+As an open source project, we welcome feedback from users or developers in the form of comments or proposals for new features or changes.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,26 @@ Other features include viewing all the classes that occur in a given lecture roo
 
 ![schedubuddy.com example usage](https://i.imgur.com/rXbTPxY.png)
 
+### Installation
+
+To set up the project for development, you will need Node.js and npm installed on your system.
+
+1. Clone the repository:
+
+   `git clone https://github.com/Exanut/schedubuddy-web.git`
+
+2. Navigate to the project directory:
+
+   `cd schedubuddy-web`
+
+3. Install dependencies:
+
+   `npm install`
+
+4. Start the development server:
+
+   `npm start`
+
 ### Contributing
 
 As an open source project, we welcome feedback from users or developers in the form of comments or proposals for new features or changes.

--- a/README.md
+++ b/README.md
@@ -16,19 +16,27 @@ To set up the project for development, you will need Node.js and npm installed o
 
 1. Clone the repository:
 
-   `git clone https://github.com/Exanut/schedubuddy-web.git`
+   ```
+   git clone https://github.com/Exanut/schedubuddy-web.git
+   ```
 
 2. Navigate to the project directory:
 
-   `cd schedubuddy-web`
+   ```
+   cd schedubuddy-web
+   ```
 
 3. Install dependencies:
 
-   `npm install`
+   ```
+   npm install
+   ```
 
 4. Start the development server:
 
-   `npm start`
+   ```
+   npm start
+   ```
 
 ### Contributing
 

--- a/src/components/Schedule.jsx
+++ b/src/components/Schedule.jsx
@@ -109,6 +109,32 @@ const drawText = (
   });
 };
 
+const drawTerm = (ctx, fullTerm, imageWidth) => {
+  const [termName, , year] = fullTerm.split(" "); // fullTerm = "Winter Term 2024"
+
+  const termAreaWidth = imageWidth / 11;
+  const boxCenterX = termAreaWidth / 2;
+  const boxCenterY = topMarginOffset / 2;
+
+  ctx.save();
+  ctx.fillStyle = "white";
+  ctx.fillRect(2, 2, termAreaWidth, topMarginOffset - 6);
+
+  ctx.fillStyle = blackColor;
+  ctx.font = `bold ${fontSize * 1.2}px Verdana`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+
+  const textYOffset = ctx.measureText("M").width;
+  const textY1 = boxCenterY - textYOffset / 2;
+  const textY2 = boxCenterY + textYOffset / 2 + 5;
+
+  ctx.fillText(termName, boxCenterX, textY1);
+  ctx.fillText(year, boxCenterX, textY2);
+
+  ctx.restore();
+};
+
 const drawSchedule = (
   ctx,
   courseOrder,
@@ -255,7 +281,7 @@ const setupCanvas = (canvas, image, fontSize) => {
   return ctx;
 };
 
-const Schedule = ({ courseOrder, jsonSched, aliases, showInstructorNames }) => {
+const Schedule = ({ courseOrder, term, jsonSched, aliases, showInstructorNames }) => {
   const canvasRef = useRef(null);
   const [image, setImage] = useState(null);
   const [dataURL, setDataURL] = useState("");
@@ -267,8 +293,9 @@ const Schedule = ({ courseOrder, jsonSched, aliases, showInstructorNames }) => {
   }, []);
 
   useEffect(() => {
-    if (image && canvasRef.current) {
+    if (image && canvasRef.current && term) {
       const ctx = setupCanvas(canvasRef.current, image, fontSize);
+      drawTerm(ctx, term, image.naturalWidth);
       drawSchedule(
         ctx,
         courseOrder,
@@ -280,7 +307,7 @@ const Schedule = ({ courseOrder, jsonSched, aliases, showInstructorNames }) => {
       );
       setDataURL(convertCanvasToImage("canvas"));
     }
-  }, [courseOrder, jsonSched, image, aliases, showInstructorNames]);
+  }, [courseOrder, term, jsonSched, image, aliases, showInstructorNames]);
 
   return (
     <>

--- a/src/layouts/Main.jsx
+++ b/src/layouts/Main.jsx
@@ -101,6 +101,9 @@ const fetchTerms = async () => {
 
 const Main = () => {
   const [terms, setTerms] = useState(null);
+  const [selectedTerm, setSelectedTerm] = useState(
+    initialValues.scheduleTerm.label || ""
+  );
   const [scheduleResponse, setScheduleResponse] = useState(blankResponse); // ScheduleBuilder and OccupancyViewer result state
   const [freeRooms, setFreeRooms] = useState([]);
   const [courseOrder, setCourseOrder] = useState([]);
@@ -125,6 +128,11 @@ const Main = () => {
     try {
       setLoading(true);
       setCourseOrder(courses.map((course) => course.course)); // Set the courseId order for color parity between autocomplete chips and schedule canvas
+      const selectedTermObject = terms.find(
+        (termObject) => termObject.value === scheduleTerm
+      );
+      const termTitle = selectedTermObject ? selectedTermObject.label : "";
+      setSelectedTerm(termTitle);
       const course_ids = courses.map((course) => course.course).join(",");
       const eveningClassesBit = evening === true ? "1" : "0";
       const onlineClassesBit = online === true ? "1" : "0";
@@ -149,6 +157,11 @@ const Main = () => {
       setLoading(true);
       const req_url = `${API_URL}/api/v1/room-sched/?term=${roomTerm}&room=${room.location}`;
       const data = await fetch(req_url).then((res) => res.json());
+      const selectedTermObject = terms.find(
+        (termObject) => termObject.value === roomTerm
+      );
+      const termTitle = selectedTermObject ? selectedTermObject.label : "";
+      setSelectedTerm(termTitle);
       setScheduleResponse(data);
       const roomSchedule = data.objects.schedules[0].slice().sort((a, b) => {
         a = a.objects.course.split(" ");
@@ -217,6 +230,7 @@ const Main = () => {
         <ScheduleContainer
           aliases={scheduleResponse.objects.aliases}
           courseOrder={courseOrder}
+          term={selectedTerm}
           schedules={scheduleResponse.objects.schedules}
           errmsg={scheduleResponse.objects.errmsg}
           componentData={componentData}
@@ -229,6 +243,7 @@ const Main = () => {
         <ScheduleContainer
           aliases={scheduleResponse.objects.aliases}
           courseOrder={courseOrder}
+          term={selectedTerm}
           schedules={scheduleResponse.objects.schedules}
           errmsg={scheduleResponse.objects.errmsg}
           componentData={null}

--- a/src/layouts/ScheduleContainer.jsx
+++ b/src/layouts/ScheduleContainer.jsx
@@ -33,7 +33,7 @@ const UnstyledScheduleContainer = ({
   const [page, setPage] = useState(0);
 
   const handlePageChange = (_e, value) => {
-    // onChange called with null value if elipses is clicked
+    // onChange called with null value if ellipses is clicked
     if (value !== null) {
       setPage(value - 1);
     }

--- a/src/layouts/ScheduleContainer.jsx
+++ b/src/layouts/ScheduleContainer.jsx
@@ -23,6 +23,7 @@ const MiniFormControlLabel = styled(FormControlLabel)({
 const UnstyledScheduleContainer = ({
   className,
   courseOrder,
+  term,
   schedules,
   aliases,
   errmsg,
@@ -55,6 +56,7 @@ const UnstyledScheduleContainer = ({
         {schedules.length ? (
           <Schedule
             courseOrder={courseOrder}
+            term={term}
             jsonSched={schedules[page]}
             aliases={aliases}
             showInstructorNames={showInstructorNames}


### PR DESCRIPTION
### Changes
- propagate termTitle from API fetch through to draw schedule
- draw termTitle box over default "Draft Schedule" boilerplate, and match Beartracks style
- add installation steps in README and fix minor typos

### Sample
![image](https://github.com/aarctan/schedubuddy-web/assets/69805659/5f363d14-f1f6-4568-a685-585c4ce0a192)
